### PR TITLE
truncated doc titles in sidebar

### DIFF
--- a/app/components/sidebar-app-left.tsx
+++ b/app/components/sidebar-app-left.tsx
@@ -87,7 +87,7 @@ export function SidebarApp({ side, data, user, ...props }: SidebarAppProps) {
       </SidebarHeader>
       <SidebarContent>
         <fetcher.Form method="get" action="/workspace/document-search" onSubmit={handleSearchSubmit}>
-          <input className="text-xs py-2 pl-4 pr-2" type="text" name="query" placeholder="search" value={query} onChange={(e) => {setQuery(e.target.value)}}/>
+          <input className="text-xs py-2 pl-4 pr-2" type="text" name="query" placeholder="search" value={query} onChange={(e) => { setQuery(e.target.value) }} />
           {searchResults.length > 0 ? <>
             <TooltipProvider>
               <Tooltip>
@@ -178,7 +178,7 @@ export function SidebarApp({ side, data, user, ...props }: SidebarAppProps) {
                       ? document.title
                       : (document.url || document.id)
                     return (
-                      <NavLink key={document.id} to={"/workspace/document/" + document.id}>
+                      <NavLink className="truncate" key={document.id} to={"/workspace/document/" + document.id}>
                         <SidebarMenuItem key={document.id}>
                           <SidebarMenuButton className="w-full justify-start text-xs">
                             <FileText className="mr-2 h-4 w-4" />


### PR DESCRIPTION
Too-long titles overflowed uglily, now they truncate.
<img width="193" height="215" alt="Screenshot 2025-10-06 at 6 55 33 PM" src="https://github.com/user-attachments/assets/e284320b-c6f0-4b0b-99e6-e1829f2202eb" />
<img width="181" height="171" alt="Screenshot 2025-10-06 at 6 58 01 PM" src="https://github.com/user-attachments/assets/1e11afbe-cb57-4c77-9234-8cb258bbe25a" />
