### PR TITLE
added tooltips to show full title when truncated

### DIFF
--- a/app/components/sidebar-app-left.tsx
+++ b/app/components/sidebar-app-left.tsx
@@ -89,57 +89,50 @@ export function SidebarApp({ side, data, user, ...props }: SidebarAppProps) {
         <fetcher.Form method="get" action="/workspace/document-search" onSubmit={handleSearchSubmit}>
           <input className="text-xs py-2 pl-4 pr-2" type="text" name="query" placeholder="search" value={query} onChange={(e) => { setQuery(e.target.value) }} />
           {searchResults.length > 0 ? <>
-            <TooltipProvider>
-              <Tooltip>
-                <TooltipTrigger asChild>
-                  <Button size="icon" variant="ghost" onClick={() => {
-                    setSearchResults([])
-                    setQuery("")
-                  }}>
-                    <SearchX className="h-5 w-5" />
-                    <span className="sr-only">clear search</span>
-                  </Button>
-                </TooltipTrigger>
-                <TooltipContent>
-                  <p>Clear Search</p>
-                </TooltipContent>
-              </Tooltip>
-            </TooltipProvider>
+            <Tooltip>
+              <TooltipTrigger asChild>
+                <Button size="icon" variant="ghost" onClick={() => {
+                  setSearchResults([])
+                  setQuery("")
+                }}>
+                  <SearchX className="h-5 w-5" />
+                  <span className="sr-only">clear search</span>
+                </Button>
+              </TooltipTrigger>
+              <TooltipContent>
+                <p>Clear Search</p>
+              </TooltipContent>
+            </Tooltip>
           </>
             :
             <>
-              <TooltipProvider>
-                <Tooltip>
-                  <TooltipTrigger asChild>
-                    <Button size="icon" variant="ghost" type="submit">
-                      <Search className="h-5 w-5" />
-                      <span className="sr-only">search</span>
-                    </Button>
-                  </TooltipTrigger>
-                  <TooltipContent>
-                    <p>Search</p>
-                  </TooltipContent>
-                </Tooltip>
-              </TooltipProvider>
-
+              <Tooltip>
+                <TooltipTrigger asChild>
+                  <Button size="icon" variant="ghost" type="submit">
+                    <Search className="h-5 w-5" />
+                    <span className="sr-only">search</span>
+                  </Button>
+                </TooltipTrigger>
+                <TooltipContent>
+                  <p>Search</p>
+                </TooltipContent>
+              </Tooltip>
             </>
           }
         </fetcher.Form>
         <Form method="post" action="document-create" onSubmit={handleNewDocSubmit}>
           <input className="text-xs py-2 pl-4 pr-2" type="text" name="url" value={url} onInput={handleUrlInput} placeholder="new document url" />
-          <TooltipProvider>
-            <Tooltip>
-              <TooltipTrigger asChild>
-                <Button size="icon" variant="ghost" type="submit">
-                  <FilePlus2 className="h-5 w-5" />
-                  <span className="sr-only">New Document</span>
-                </Button>
-              </TooltipTrigger>
-              <TooltipContent>
-                <p>New Document</p>
-              </TooltipContent>
-            </Tooltip>
-          </TooltipProvider>
+          <Tooltip>
+            <TooltipTrigger asChild>
+              <Button size="icon" variant="ghost" type="submit">
+                <FilePlus2 className="h-5 w-5" />
+                <span className="sr-only">New Document</span>
+              </Button>
+            </TooltipTrigger>
+            <TooltipContent>
+              <p>New Document</p>
+            </TooltipContent>
+          </Tooltip>
         </Form>
         <div className="flex flex-col gap-4">
           <SidebarGroup>
@@ -155,6 +148,7 @@ export function SidebarApp({ side, data, user, ...props }: SidebarAppProps) {
                   return (
                     <NavLink key={match.documentId} to={"/workspace/document/" + match.documentId}>
                       <SidebarMenuItem key={match.documentId}>
+
                         <SidebarMenuButton className="w-full justify-start text-xs flex flex-row">
                           <FileText className="mr-2 h-4 w-4" />
                           <div className="flex flex-col">
@@ -178,14 +172,21 @@ export function SidebarApp({ side, data, user, ...props }: SidebarAppProps) {
                       ? document.title
                       : (document.url || document.id)
                     return (
-                      <NavLink className="truncate" key={document.id} to={"/workspace/document/" + document.id}>
-                        <SidebarMenuItem key={document.id}>
-                          <SidebarMenuButton className="w-full justify-start text-xs">
-                            <FileText className="mr-2 h-4 w-4" />
-                            {title}
-                          </SidebarMenuButton>
-                        </SidebarMenuItem>
-                      </NavLink>
+                      <Tooltip>
+                        <TooltipTrigger asChild>
+                          <NavLink className="truncate" key={document.id} to={"/workspace/document/" + document.id}>
+                            <SidebarMenuItem key={document.id}>
+                              <SidebarMenuButton className="w-full justify-start text-xs">
+                                <FileText className="mr-2 h-4 w-4" />
+                                {title}
+                              </SidebarMenuButton>
+                            </SidebarMenuItem>
+                          </NavLink>
+                        </TooltipTrigger>
+                        <TooltipContent side="right" align="center" className="max-w-xs">
+                          <p>{title}</p>
+                        </TooltipContent>
+                      </Tooltip>
                     )
                   })}
                 </SidebarMenu>

--- a/app/routes/layout.tsx
+++ b/app/routes/layout.tsx
@@ -22,6 +22,7 @@ import {
 import { SidebarApp as SidebarLeft } from "~/components/sidebar-app-left";
 import { SidebarApp as SidebarRight } from "~/components/sidebar-app-right";
 import { useRef, useState } from "react";
+import { TooltipProvider } from "../components/ui/tooltip";
 
 
 export const loader = async ({ request, params }: Route.LoaderArgs) => {
@@ -54,34 +55,36 @@ const Layout = ({ loaderData }: Route.ComponentProps) => {
   return (
     <>
       {/* documents chats */}
-      <LeftSidebarProvider>
-        <SidebarLeft side="left" data={loaderData.documents} user={uiUser} />
-        <RightSidebarProvider>
-          <SidebarInset className="flex flex-col h-screen overflow-y-auto">
-            <header className="sticky top-0 flex h-14 shrink-0 items-center gap-2 z-50 backdrop-blur-sm rounded-md">
-              <div className="flex flex-1 justify-between items-center gap-2 px-3">
-                <SidebarTriggerLeft />
-                {/* <Separator orientation="vertical" className="mr-2 h-4" /> */}
-                <Breadcrumb>
-                  <BreadcrumbList>
-                    <BreadcrumbItem>
-                      <BreadcrumbPage className="line-clamp-1 items-center">
-                        <span className="">{loaderData.document?.title ?? ""} - </span>
-                        <span className="text-xs">{loaderData.authors ?? ""}</span>
-                      </BreadcrumbPage>
-                    </BreadcrumbItem>
-                  </BreadcrumbList>
-                </Breadcrumb>
-                <SidebarTriggerRight />
-              </div>
-            </header>
-            <Outlet context={{ selectionRef, setShowHighlight, setIncludeSelection }} />
-          </SidebarInset>
-          <SidebarRight side="right" data={loaderData.chats} user={uiUser} selectionRef={selectionRef} includeSelection={includeSelection} setIncludeSelection={setIncludeSelection} />
-          {/* <SidebarInset className="flex flex-col h-screen overflow-y-auto">
-          </SidebarInset> */}
-        </RightSidebarProvider>
-      </LeftSidebarProvider>
+      <TooltipProvider delayDuration={1500}>
+        <LeftSidebarProvider>
+          <SidebarLeft side="left" data={loaderData.documents} user={uiUser} />
+          <RightSidebarProvider>
+            <SidebarInset className="flex flex-col h-screen overflow-y-auto">
+              <header className="sticky top-0 flex h-14 shrink-0 items-center gap-2 z-50 backdrop-blur-sm rounded-md">
+                <div className="flex flex-1 justify-between items-center gap-2 px-3">
+                  <SidebarTriggerLeft />
+                  {/* <Separator orientation="vertical" className="mr-2 h-4" /> */}
+                  <Breadcrumb>
+                    <BreadcrumbList>
+                      <BreadcrumbItem>
+                        <BreadcrumbPage className="line-clamp-1 items-center">
+                          <span className="">{loaderData.document?.title ?? ""} - </span>
+                          <span className="text-xs">{loaderData.authors ?? ""}</span>
+                        </BreadcrumbPage>
+                      </BreadcrumbItem>
+                    </BreadcrumbList>
+                  </Breadcrumb>
+                  <SidebarTriggerRight />
+                </div>
+              </header>
+              <Outlet context={{ selectionRef, setShowHighlight, setIncludeSelection }} />
+            </SidebarInset>
+            <SidebarRight side="right" data={loaderData.chats} user={uiUser} selectionRef={selectionRef} includeSelection={includeSelection} setIncludeSelection={setIncludeSelection} />
+            {/* <SidebarInset className="flex flex-col h-screen overflow-y-auto">
+            </SidebarInset> */}
+          </RightSidebarProvider>
+        </LeftSidebarProvider>
+      </TooltipProvider>
     </>
   )
 }


### PR DESCRIPTION
like the title says. Began clearing up redundant TooltipProvider calls, as the provider can be wrapped at the app level, and doesn't work to control Tooltip anyway. There's a bug where Tooltip is written to provide its own secret TooltipProvider under the hood, and thus does not obey the outer provider. Will need to write a reusable workaround tomorrow, as this will likely cause us issues when rendering the annotations and comments later.